### PR TITLE
Fix retryCount after internet connection is back

### DIFF
--- a/src/client/socket/index.js
+++ b/src/client/socket/index.js
@@ -107,6 +107,8 @@ function onMessageReceived(buffer, NotificationSchema, keys, persistentIds) {
     }
     const message = decrypt(object, keys);
     if (message) {
+      // Maintain persistentIds updated with the very last received value
+      persistentIds.push(object.persistentId);
       // Send notification
       emitter.emit(ON_NOTIFICATION_RECEIVED, {
         notification : message,

--- a/src/client/socket/index.js
+++ b/src/client/socket/index.js
@@ -27,7 +27,7 @@ async function connect(
   persistentIds
 ) {
   // Retry on disconnect
-  retry = connect.bind(
+  const retry = connect.bind(
     this,
     payload,
     RequestType,
@@ -44,7 +44,7 @@ async function connect(
   socket.write(
     Buffer.concat([preBuffer, buffer], preBuffer.length + buffer.length)
   );
-  // Listen for incoming messages  
+  // Listen for incoming messages
   return listen(socket, NotificationSchema, keys, persistentIds);
 }
 
@@ -57,7 +57,7 @@ function connectSocket(retryCallback) {
       const minutes = Math.round((diff[0] + diff[1] / 1e9) / 60);
       const retryTempo = Math.min(retryCount++, RETRY_MAX_TEMPO);
       console.warn(`MCS socket closed after ${minutes} minutes`);
-      console.warn(`Will try to reconnect in ${retryTempo}`);
+      console.warn(`Will try to reconnect in ${retryTempo} seconds`);
       setTimeout(() => retryCallback(), retryTempo * 1000);
     });
     socket.on('error', error => {

--- a/src/client/socket/index.js
+++ b/src/client/socket/index.js
@@ -5,6 +5,7 @@ const decrypt = require('../../utils/decrypt');
 const HOST = 'mtalk.google.com';
 const PORT = 5228;
 const RETRY_MAX_TEMPO = 15; // maximum time before retrying to open the socket (in seconds)
+let retryCount = 0;         // retries count of opening socket attempts
 
 const ON_NOTIFICATION_RECEIVED = 'ON_NOTIFICATION_RECEIVED';
 
@@ -23,21 +24,19 @@ async function connect(
   preBuffer,
   NotificationSchema,
   keys,
-  persistentIds,
-  retryCount = 0
+  persistentIds
 ) {
   // Retry on disconnect
-  const retry = connect.bind(
+  retry = connect.bind(
     this,
     payload,
     RequestType,
     preBuffer,
     NotificationSchema,
     keys,
-    persistentIds,
-    retryCount + 1
+    persistentIds
   );
-  const socket = await connectSocket(retry, retryCount);
+  const socket = await connectSocket(retry);
   timer = process.hrtime();
   console.info('MCS client connected');
   // Payload to send to login with MCS server
@@ -45,21 +44,21 @@ async function connect(
   socket.write(
     Buffer.concat([preBuffer, buffer], preBuffer.length + buffer.length)
   );
-  // Listen for incoming messages
+  // Listen for incoming messages  
   return listen(socket, NotificationSchema, keys, persistentIds);
 }
 
-function connectSocket(retry, retryCount) {
+function connectSocket(retryCallback) {
   return new Promise(resolve => {
     const socket = new tls.TLSSocket();
     socket.setKeepAlive(true);
     socket.on('close', () => {
       const diff = process.hrtime(timer);
       const minutes = Math.round((diff[0] + diff[1] / 1e9) / 60);
-      const retryTempo = Math.min(retryCount, RETRY_MAX_TEMPO);
+      const retryTempo = Math.min(retryCount++, RETRY_MAX_TEMPO);
       console.warn(`MCS socket closed after ${minutes} minutes`);
-      console.warn(`Will try to reconnect in ${retryTempo} seconds`);
-      setTimeout(() => retry(), retryTempo * 1000);
+      console.warn(`Will try to reconnect in ${retryTempo}`);
+      setTimeout(() => retryCallback(), retryTempo * 1000);
     });
     socket.on('error', error => {
       if (error.code === 'ECONNRESET') {

--- a/src/client/socket/index.js
+++ b/src/client/socket/index.js
@@ -49,14 +49,14 @@ async function connect(
   return listen(socket, NotificationSchema, keys, persistentIds);
 }
 
-function connectSocket(retry, retryCount) {  
+function connectSocket(retry, retryCount) {
   return new Promise(resolve => {
     const socket = new tls.TLSSocket();
     socket.setKeepAlive(true);
     socket.on('close', () => {
       const diff = process.hrtime(timer);
       const minutes = Math.round((diff[0] + diff[1] / 1e9) / 60);
-      let retryTempo = Math.min(retryCount, RETRY_MAX_TEMPO);
+      const retryTempo = Math.min(retryCount, RETRY_MAX_TEMPO);
       console.warn(`MCS socket closed after ${minutes} minutes`);
       console.warn(`Will try to reconnect in ${retryTempo} seconds`);
       setTimeout(() => retry(), retryCount * 1000);


### PR DESCRIPTION
When the internet connection is down again after being lost one first time, the reseted `retryCount` value is now taken into account and the retry attempts (`socket.connect()`) are well delayed in a progressive way (1, 2, 3, 4, ... 15 seconds)
The fix is based on a global value:
```javascript
let retryCount = 0;         // retries count of opening socket attempts
```
