### PR TITLE
Receive Android's app notification

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,17 +1,14 @@
 {
   "name": "push-receiver",
   "version": "1.1.5",
-  "description":
-    "A module to subscribe to GCM/FCM and receive notifications within a node process.",
+  "description": "A module to subscribe to GCM/FCM and receive notifications within a node process.",
   "main": "src/index.js",
   "scripts": {
     "start": "node scripts/listen",
     "register": "node scripts/register",
     "send": "node scripts/send",
-    "pretty":
-      "prettier-eslint --single-quote --trailing-comma es5 --write \"**/*.js\" \"**/*.json\"",
-    "pretty:check":
-      "prettier-eslint --single-quote --trailing-comma es5 --list-different --log-level silent \"**/*.js\" \"**/*.json\"",
+    "pretty": "prettier-eslint --single-quote --trailing-comma es5 --write \"**/*.js\" \"**/*.json\"",
+    "pretty:check": "prettier-eslint --single-quote --trailing-comma es5 --list-different --log-level silent \"**/*.js\" \"**/*.json\"",
     "lint": "eslint 'src/**/*.js'",
     "lint:fix": "eslint 'src/**/*.js' --fix"
   },
@@ -46,6 +43,7 @@
     "yargs": "^10.0.3"
   },
   "dependencies": {
+    "debug": "^3.1.0",
     "http_ece": "^1.0.5",
     "long": "^3.2.0",
     "protobufjs": "^6.8.0",

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -14,9 +14,26 @@ function loadProtoFile() {
   return protobuf.load(path.join(__dirname, 'mcs.proto'));
 }
 
+function getProtocol( proto ) {
+  const tags = [
+    { tag : 0, name : 'HeartbeatPing' },
+    { tag : 1, name : 'HeartbeatAck' },
+    { tag : 2, name : 'LoginRequest' },
+    { tag : 3, name : 'LoginResponse' },
+    { tag : 4, name : 'Close' },
+    { tag : 7, name : 'IqStanza' },
+    { tag : 8, name : 'DataMessageStanza' },
+  ];
+
+  return tags.map( tagInfo => ( {
+    ...tagInfo,
+    type : proto.lookupType(`mcs_proto.${tagInfo.name}`),
+  } ) );
+}
+
 function login({ androidId, securityToken }, proto, keys, persistentIds = []) {
-  const LoginRequestType = proto.lookupType('mcs_proto.LoginRequest');
-  const DataMessageStanza = proto.lookupType('mcs_proto.DataMessageStanza');
+  const protocol = getProtocol(proto);
+
   const hexAndroidId = Long.fromString(androidId).toString(16);
   const loginRequest = {
     adaptiveHeartbeat    : false,
@@ -33,15 +50,10 @@ function login({ androidId, securityToken }, proto, keys, persistentIds = []) {
     // Id of the last notification received
     clientEvent          : [],
     // FIXME Figure out how to pass persistentIds without being kickout by Google
-    receivedPersistentId : [],
+    receivedPersistentId : persistentIds,
   };
   return socketConnect(
     loginRequest,
-    LoginRequestType,
-    // FIXME Can change depending on persistentIds
-    Buffer.from([41, 2, 149, 1]),
-    DataMessageStanza,
-    keys,
-    persistentIds
+    protocol,
   );
 }

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -5,9 +5,9 @@ const { connect: socketConnect } = require('./socket');
 
 module.exports = connect;
 
-async function connect(gcmParams, keys, persistentIds) {
+async function connect(gcmParams, keys, persistentIds, notificationCallback, loginCallback) {
   const proto = await loadProtoFile();
-  return login(gcmParams, proto, keys, persistentIds);
+  return login(gcmParams, proto, keys, persistentIds, notificationCallback, loginCallback);
 }
 
 function loadProtoFile() {
@@ -31,7 +31,7 @@ function getProtocol( proto ) {
   } ) );
 }
 
-function login({ androidId, securityToken }, proto, keys, persistentIds = []) {
+function login({ androidId, securityToken }, proto, keys, persistentIds = [], notificationCallback, loginCallback) {
   const protocol = getProtocol(proto);
 
   const hexAndroidId = Long.fromString(androidId).toString(16);
@@ -55,5 +55,7 @@ function login({ androidId, securityToken }, proto, keys, persistentIds = []) {
   return socketConnect(
     loginRequest,
     protocol,
+    notificationCallback,
+    loginCallback
   );
 }

--- a/src/client/socket/index.js
+++ b/src/client/socket/index.js
@@ -1,5 +1,4 @@
 const tls = require('tls');
-const EventEmitter = require('events');
 const debug = require( 'debug' )( 'push-reciever:socket' );
 
 const MCS_VERSION = 41;
@@ -128,24 +127,25 @@ function listen(socket, protocol, notificationCallback, loginCallback) {
       return;
     }
 
-    const tagId = buffer.readUIntBE(0, 1);
-    const sizeVarInt = readVarInt(buffer, 1);
-
-    if ( buffer.length === sizeVarInt.value + 1 + sizeVarInt.bytes ) { // one byte tagId and one or more byte for size varint
-      prevBuffer = null;
-    } else {
-      prevBuffer = buffer;
-      return;
-    }
-
-    const currentTag = protocol.find(tag => tag.tag === tagId);
-
-    if ( ! currentTag ) {
-      debug('Unable to find tag id ' + tagId);
-      return;
-    }
-
     try {
+      const tagId = buffer.readUIntBE(0, 1);
+      const sizeVarInt = readVarInt(buffer, 1);
+
+      if ( buffer.length === sizeVarInt.value + 1 + sizeVarInt.bytes ) { // one byte tagId and one or more byte for size varint
+        prevBuffer = null;
+      } else {
+        prevBuffer = buffer;
+        return;
+      }
+
+      const currentTag = protocol.find(tag => tag.tag === tagId);
+
+      if ( ! currentTag ) {
+        debug('Unable to find tag id ' + tagId);
+        return;
+      }
+
+
       const msg = currentTag.type.decodeDelimited( buffer.slice(1) );
 
       debug( `Recieved ${ currentTag.name }: ${ JSON.stringify( msg ) }` );
@@ -165,7 +165,7 @@ function listen(socket, protocol, notificationCallback, loginCallback) {
       }
 
     } catch(e) {
-      debug( `Unable to parse tag ${currentTag.name} ${ buffer.toString('hex') } error: ${ e }`);
+      debug( `Error processing buffer ${ buffer.toString('hex') } of length: ${ buffer.length } error: ${ e }`);
     }
   } );
 

--- a/src/client/socket/index.js
+++ b/src/client/socket/index.js
@@ -7,7 +7,6 @@ const PORT = 5228;
 const RETRY_MAX_TEMPO = 15; // maximum time before retrying to open the socket (in seconds)
 let retryCount = 0;         // retries count of opening socket attempts
 const STATES = [ 'connecting', 'seenversion', 'loggedin' ];
-let state = STATES[0];
 
 let timer;
 
@@ -119,6 +118,7 @@ function connectSocket(retry) {
 
 function listen(socket, protocol, notificationCallback, loginCallback) {
   let prevBuffer = null;
+  let state = STATES[0];
   socket.on('data', currentBuffer => {
     const buffer = prevBuffer ? Buffer.concat( [ prevBuffer, currentBuffer ] ) : currentBuffer;
 

--- a/src/gcm/index.js
+++ b/src/gcm/index.js
@@ -19,9 +19,9 @@ module.exports = {
   checkIn,
 };
 
-async function register(appId) {
+async function register(senderId, appId, appVer, appCert) {
   const options = await checkIn();
-  const credentials = await doRegister(options, appId);
+  const credentials = await doRegister(options, senderId, appId, appVer, appCert);
   return credentials;
 }
 
@@ -46,13 +46,16 @@ async function checkIn(androidId, securityToken) {
   return object;
 }
 
-async function doRegister({ androidId, securityToken }, appId) {
+async function doRegister({ androidId, securityToken }, senderId, appId, appVer, appCert) {
   const body = {
-    app         : 'org.chromium.linux',
-    'X-subtype' : appId,
+    app         : appId,
     device      : androidId,
-    sender      : serverKey,
+    cert        : appCert,
+    app_ver     : appVer,
   };
+
+  [ 'sender', 'X-subtype', 'X-X-subtype', 'X-subscription', 'X-X-subscription' ].forEach( key => body[ key ] = senderId );
+
   const response = await postRegister({ androidId, securityToken, body });
   const token = response.split('=')[1];
   return {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 const connect = require('./client');
-const { ON_NOTIFICATION_RECEIVED, emitter } = require('./client/socket');
 const { checkIn } = require('./gcm');
 const register = require('./register');
 
@@ -8,7 +7,7 @@ module.exports = {
   register,
 };
 
-async function listen(credentials, notificationCallback) {
+async function listen(credentials, notificationCallback, loginCallback) {
   if (!credentials) {
     throw new Error('Missing credentials');
   }
@@ -31,6 +30,11 @@ async function listen(credentials, notificationCallback) {
     throw new Error('Missing keys.authSecret in credentials');
   }
   await checkIn(credentials.gcm.androidId, credentials.gcm.securityToken);
-  emitter.on(ON_NOTIFICATION_RECEIVED, notificationCallback);
-  await connect(credentials.gcm, credentials.keys, credentials.persistentIds);
+  return await connect(
+    credentials.gcm,
+    credentials.keys,
+    credentials.persistentIds,
+    notificationCallback,
+    loginCallback
+  );
 }

--- a/src/register/index.js
+++ b/src/register/index.js
@@ -4,10 +4,9 @@ const registerFCM = require('../fcm');
 
 module.exports = register;
 
-async function register(senderId) {
+async function register(senderId, appId, appVer, appCert) {
   // Should be unique by app - One GCM registration/token by app/appId
-  const appId = `wp:receiver.push.com#${uuidv4()}`;
-  const subscription = await registerGCM(appId);
+  const subscription = await registerGCM(senderId, appId, appVer, appCert);
   const result = await registerFCM({
     token : subscription.token,
     senderId,


### PR DESCRIPTION
Hi,

I don't expect you to merge it as is obviously =) But just wanted to loopback here in case someone is looking to do something similar.

Thank you for this project.

In my use case I needed to receive push notifications that were sent to an actual android app via GCM (not FCM).

The code weren't working for me out of the box, so I made the following changes:
1. Allow passing appId and other parameters to `register()` in order to properly register as the android app
2. Modified protocol handling - reading the message tag (1 byte) and size (varint) before the actual GCM message. The messages I'm getting from GCM are not encrypted, so I droped it. `LoginRequest` weren't correctly sent because size was hard-coded.

Another good reference for GCM implementation is [microG project](https://github.com/microg/android_packages_apps_GmsCore/blob/master/play-services-core/src/main/java/org/microg/gms/gcm/McsService.java)

Register the same way the android app does it:
```
const { register } = require('../../src');
const fs = require( 'fs' );

const senderId = ''; // project number == senderId => https://support.clevertap.com/docs/android/how-to-find-your-gcm-sender-id-and-gcm-api-server-key.html
const appId = ''; // app package name, i.e. com.google.calendar
const appVer = 514; // ??? not sure how that's calculated

/*
https://stackoverflow.com/questions/11331469/how-do-i-find-out-which-keystore-was-used-to-sign-an-app

unzip app.apk
keytool -printcert -file META-INF/CERT.RSA 
output:
Certificate fingerprints:
	 SHA1: 16:59:E7:E3:0C:AA:7A:0D:F2:0D:05:20:12:A8:85:0B:32:C5:4F:68 <=== That's the one, remove the colons
*/
const appCert = '';

// Register to GCM and FCM
register( senderId, appId, appVer, appCert ).then( credentials => {
	console.log( credentials ); // Store credentials to use it later
	fs.writeFileSync( 'credentials.json', JSON.stringify( credentials ) );
} );
```