### PR TITLE
Add disconnect event to the client

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -136,6 +136,7 @@ module.exports = class Client extends EventEmitter {
   }
 
   _onSocketClose() {
+    this.emit('disconnect')
     this._retry();
   }
 


### PR DESCRIPTION
This event might come in handy for some when someone wants to
use a push message and use a polling system as fallback if disconnected or push message
is, why ever, not working.