### PR TITLE
typescript type declarations, option to register without registerFCM()

### DIFF
--- a/src/gcm/index.js
+++ b/src/gcm/index.js
@@ -8,8 +8,8 @@ const { toBase64 } = require('../utils/base64');
 
 // Hack to fix PHONE_REGISTRATION_ERROR #17 when bundled with webpack
 // https://github.com/dcodeIO/protobuf.js#browserify-integration
-protobuf.util.Long = Long
-protobuf.configure()
+protobuf.util.Long = Long;
+protobuf.configure();
 
 const serverKey = toBase64(Buffer.from(fcmKey));
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,72 @@
+declare module 'push-receiver' {
+
+  export function listen(
+    credentials: Credentials,
+    notificationCallback: (notification: NotificationEnvelope) => unknown,
+  ): Promise<Client>;
+
+  export function register(
+    senderId: string,
+    options?: {
+      noFcmRegistration?: false | null,
+    },
+  ): Promise<Credentials & FcmData>;
+
+  export function register(
+    senderId: string,
+    options: {
+      noFcmRegistration: true,
+    },
+  ): Promise<Credentials>;
+
+  export interface Credentials {
+    keys: Keys;
+    gcm: GcmData;
+    persistentIds: PersistentId[];
+  }
+
+  export interface Keys {
+    privateKey: string;
+    publicKey: string;
+    authSecret: string;
+  }
+
+  export interface GcmData {
+    androidId: string;
+    token: string;
+    securityToken: string;
+  }
+
+  // TODO: replace this with actual data
+  export type FcmData = any;
+
+  export type PersistentId = string;
+
+  export interface NotificationEnvelope {
+    notification: NotificationContent;
+    persistentId: PersistentId;
+  }
+
+  // table 2b. - https://firebase.google.com/docs/cloud-messaging/http-server-ref
+  export interface NotificationContent {
+    title?: string;
+    body?: string;
+    android_channel_id?: string;
+    icon?: string;
+    sound?: string;
+    tag?: string;
+    color?: string;
+    click_action?: string;
+    body_loc_key?: string;
+    body_loc_args?: string; // JSON array as string
+    title_loc_key?: string;
+    title_loc_args?: string; // JSON array as string
+  }
+
+  declare class Client {
+    on(event: 'ON_NOTIFICATION_RECEIVED', listener: (notification: NotificationEnvelope) => void): this;
+    connect(): Promise<void>;
+    destroy(): void;
+  }
+
+}

--- a/src/register/index.js
+++ b/src/register/index.js
@@ -4,10 +4,13 @@ const registerFCM = require('../fcm');
 
 module.exports = register;
 
-async function register(senderId) {
+async function register(senderId, { noFcmRegistration } = {}) {
   // Should be unique by app - One GCM registration/token by app/appId
   const appId = `wp:receiver.push.com#${uuidv4()}`;
   const subscription = await registerGCM(appId);
+  if (noFcmRegistration) {
+    return { gcm : subscription };
+  }
   const result = await registerFCM({
     token : subscription.token,
     senderId,


### PR DESCRIPTION
f9f62e7 is a workaround for #34 (some developers just need a valid token to work with some APIs, and this will be enough for them)