### PR TITLE
Fix #34 FCM registering problems and add TypeScript definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ storage.json
 web/
 .esm-cache
 test/keys.js
+.history

--- a/src/client.js
+++ b/src/client.js
@@ -136,14 +136,16 @@ module.exports = class Client extends EventEmitter {
   }
 
   _onSocketClose() {
-    this.emit('disconnect')
+    this.emit('disconnect');
     this._retry();
   }
 
+  // eslint-disable-next-line no-unused-vars
   _onSocketError(error) {
     // ignore, the close handler takes care of retry
   }
 
+  // eslint-disable-next-line no-unused-vars
   _onParserError(error) {
     this._retry();
   }

--- a/src/fcm/index.js
+++ b/src/fcm/index.js
@@ -17,15 +17,9 @@ async function registerFCM({ senderId, token }) {
     },
     form : {
       authorized_entity : senderId,
-      endpoint          : `${FCM_ENDPOINT}/${token}`,
-      encryption_key    : keys.publicKey
-        .replace(/=/g, '')
-        .replace(/\+/g, '-')
-        .replace(/\//g, '_'),
-      encryption_auth : keys.authSecret
-        .replace(/=/g, '')
-        .replace(/\+/g, '-')
-        .replace(/\//g, '_'),
+      endpoint          : escape(`${FCM_ENDPOINT}/${token}`),
+      encryption_key    : keys.publicKey,
+      encryption_auth   : keys.authSecret,
     },
   });
   return {

--- a/src/gcm/index.js
+++ b/src/gcm/index.js
@@ -8,8 +8,8 @@ const { toBase64 } = require('../utils/base64');
 
 // Hack to fix PHONE_REGISTRATION_ERROR #17 when bundled with webpack
 // https://github.com/dcodeIO/protobuf.js#browserify-integration
-protobuf.util.Long = Long
-protobuf.configure()
+protobuf.util.Long = Long;
+protobuf.configure();
 
 const serverKey = toBase64(Buffer.from(fcmKey));
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,72 @@
+declare module 'push-receiver' {
+
+  export function listen(
+    credentials: Credentials,
+    notificationCallback: (notification: NotificationEnvelope) => unknown,
+  ): Promise<Client>;
+
+  export function register(
+    senderId: string,
+    options?: {
+      bundleId?: string,
+    },
+  ): Promise<Credentials & FcmData>;
+
+  export function register(
+    senderId: string,
+    options: {
+      bundleId?: string,
+    },
+  ): Promise<Credentials>;
+
+  export interface Credentials {
+    keys: Keys;
+    gcm: GcmData;
+    persistentIds: PersistentId[];
+  }
+
+  export interface Keys {
+    privateKey: string;
+    publicKey: string;
+    authSecret: string;
+  }
+
+  export interface GcmData {
+    androidId: string;
+    token: string;
+    securityToken: string;
+  }
+
+  // TODO: replace this with actual data
+  export type FcmData = any;
+
+  export type PersistentId = string;
+
+  export interface NotificationEnvelope {
+    notification: NotificationContent;
+    persistentId: PersistentId;
+  }
+
+  // table 2b. - https://firebase.google.com/docs/cloud-messaging/http-server-ref
+  export interface NotificationContent {
+    title?: string;
+    body?: string;
+    android_channel_id?: string;
+    icon?: string;
+    sound?: string;
+    tag?: string;
+    color?: string;
+    click_action?: string;
+    body_loc_key?: string;
+    body_loc_args?: string; // JSON array as string
+    title_loc_key?: string;
+    title_loc_args?: string; // JSON array as string
+  }
+
+  declare class Client {
+    on(event: 'ON_NOTIFICATION_RECEIVED', listener: (notification: NotificationEnvelope) => void): this;
+    connect(): Promise<void>;
+    destroy(): void;
+  }
+
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -9,6 +9,7 @@ declare module 'push-receiver' {
     senderId: string,
     options?: {
       bundleId?: string,
+      skipFcmRegistration?: boolean,
     },
   ): Promise<Credentials & FcmData>;
 
@@ -16,6 +17,7 @@ declare module 'push-receiver' {
     senderId: string,
     options: {
       bundleId?: string,
+      skipFcmRegistration?: boolean,
     },
   ): Promise<Credentials>;
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -204,7 +204,7 @@ module.exports = class Parser extends EventEmitter {
     // Messages with no content are valid; just use the default protobuf for
     // that tag.
     if (this._messageSize === 0) {
-      this.emit('message', {tag: this._messageTag, object: {}});
+      this.emit('message', { tag : this._messageTag, object : {} });
       this._getNextMessage();
       return;
     }
@@ -230,7 +230,7 @@ module.exports = class Parser extends EventEmitter {
       bytes : Buffer,
     });
 
-    this.emit('message', {tag: this._messageTag, object: object});
+    this.emit('message', { tag : this._messageTag, object : object });
 
     if (this._messageTag === kLoginResponseTag) {
       if (this._handshakeComplete) {

--- a/src/register/index.js
+++ b/src/register/index.js
@@ -4,9 +4,9 @@ const registerFCM = require('../fcm');
 
 module.exports = register;
 
-async function register(senderId) {
+async function register(senderId, { bundleId } = { bundleId : 'receiver.push.com' }) {
   // Should be unique by app - One GCM registration/token by app/appId
-  const appId = `wp:receiver.push.com#${uuidv4()}`;
+  const appId = `wp:${bundleId}#${uuidv4()}`;
   const subscription = await registerGCM(appId);
   const result = await registerFCM({
     token : subscription.token,

--- a/src/register/index.js
+++ b/src/register/index.js
@@ -6,11 +6,17 @@ module.exports = register;
 
 async function register(
   senderId,
-  { bundleId } = { bundleId : 'receiver.push.com' }
+  { bundleId, skipFcmRegistration } = {
+    bundleId            : 'receiver.push.com',
+    skipFcmRegistration : false,
+  }
 ) {
   // Should be unique by app - One GCM registration/token by app/appId
   const appId = `wp:${bundleId}#${uuidv4()}`;
   const subscription = await registerGCM(appId);
+  if (skipFcmRegistration) {
+    return { gcm : subscription };
+  }
   const result = await registerFCM({
     token : subscription.token,
     senderId,

--- a/src/register/index.js
+++ b/src/register/index.js
@@ -4,7 +4,10 @@ const registerFCM = require('../fcm');
 
 module.exports = register;
 
-async function register(senderId, { bundleId } = { bundleId : 'receiver.push.com' }) {
+async function register(
+  senderId,
+  { bundleId } = { bundleId : 'receiver.push.com' }
+) {
   // Should be unique by app - One GCM registration/token by app/appId
   const appId = `wp:${bundleId}#${uuidv4()}`;
   const subscription = await registerGCM(appId);


### PR DESCRIPTION
This PR fixes #34 and makes this project work now again (at least for me). Probably the README should be updated with the new options.

- [x] Properly escape form data param `endpoint` and refactor duplicate escapes
- [x] Add option `bundleId` on register, to use a custom bundleId instead of the hardcoded `receiver.push.com`
- [x] Add option `skipFcmRegistration` on register (from #35 @selfisekai, I just renamed the option to be more convenient) 
- [x] Add TypeScript definition from (from #35)
- [x] Fix linting issues
